### PR TITLE
Fix crash when disabling music streams

### DIFF
--- a/sound/05-headers/sound_engine.asm
+++ b/sound/05-headers/sound_engine.asm
@@ -97,8 +97,8 @@ sound_load:
 
 	lda	(sound_ptr), y	; Status byte. 1=enable, 0=disable
 	sta	stream_status, x
-	;; If status byte is 0, stream disable, so we are done
-	beq	@next_stream
+	;; If status byte is 0, stream disable, move pointer
+	beq	@advance_pointer
 	iny
 
 	lda	(sound_ptr), y	; Channel number
@@ -127,6 +127,15 @@ sound_load:
 	bne	@loop
 	
 	rts
+
+@advance_pointer:
+    iny
+    iny
+    iny
+    iny
+    iny
+    jmp @next_stream
+
 
 	;; *** Change this to make the notes play faster or slower ***
 	TEMPO = $0C

--- a/sound/06-tempo/sound_engine.asm
+++ b/sound/06-tempo/sound_engine.asm
@@ -108,8 +108,8 @@ sound_load:
 
 	lda	(sound_ptr), y	; Status byte. 1=enable, 0=disable
 	sta	stream_status, x
-	;; If status byte is 0, stream disable, so we are done
-	beq	@next_stream
+	;; If status byte is 0, stream disable, advance pointer
+	beq	@advance_pointer
 	iny
 
 	lda	(sound_ptr), y	; Channel number
@@ -148,6 +148,14 @@ sound_load:
 	bne	@loop
 	
 	rts
+
+@advance_pointer:
+    iny
+    iny
+    iny
+    iny
+    iny
+    jmp @next_stream
 
 sound_play_frame:
 	lda	sound_disable_flag

--- a/sound/07-envelopes/sound_engine.asm
+++ b/sound/07-envelopes/sound_engine.asm
@@ -113,8 +113,8 @@ sound_load:
 
 	lda	(sound_ptr), y	; Status byte. 1=enable, 0=disable
 	sta	stream_status, x
-	;; If status byte is 0, stream disable, so we are done
-	beq	@next_stream
+	;; If status byte is 0, stream disable, advance pointer
+	beq	@advance_pointer
 	iny
 
 	lda	(sound_ptr), y	; Channel number
@@ -160,6 +160,14 @@ sound_load:
 	bne	@loop
 	
 	rts
+
+@advance_pointer:
+    iny
+    iny
+    iny
+    iny
+    iny
+    jmp @next_stream
 
 sound_play_frame:
 	lda	sound_disable_flag

--- a/sound/08-opcodes/sound_engine.asm
+++ b/sound/08-opcodes/sound_engine.asm
@@ -104,8 +104,8 @@ sound_load:
 
 	lda	(sound_ptr), y	; Status byte. 1=enable, 0=disable
 	sta	stream_status, x
-	;; If status byte is 0, stream disable, so we are done
-	beq	@next_stream
+	;; If status byte is 0, stream disable, advance pointer
+	beq	@advance_pointer
 	iny
 
 	lda	(sound_ptr), y	; Channel number
@@ -151,6 +151,14 @@ sound_load:
 	bne	@loop
 	
 	rts
+
+@advance_pointer:
+    iny
+    iny
+    iny
+    iny
+    iny
+    jmp @next_stream
 
 sound_play_frame:
 	lda	sound_disable_flag

--- a/sound/09-opcodes2/sound_engine.asm
+++ b/sound/09-opcodes2/sound_engine.asm
@@ -106,8 +106,8 @@ sound_load:
 
 	lda	(sound_ptr), y	; Status byte. 1=enable, 0=disable
 	sta	stream_status, x
-	;; If status byte is 0, stream disable, so we are done
-	beq	@next_stream
+	;; If status byte is 0, stream disable, advance pointer
+	beq	@advance_pointer
 	iny
 
 	lda	(sound_ptr), y	; Channel number
@@ -155,6 +155,14 @@ sound_load:
 	bne	@loop
 	
 	rts
+
+@advance_pointer:
+    iny
+    iny
+    iny
+    iny
+    iny
+    jmp @next_stream
 
 sound_play_frame:
 	lda	sound_disable_flag


### PR DESCRIPTION
I was surprised to find that this driver must not have been tested with streams disabled, because there was a small oversight where the pointer would not advance to the next stream, it would be left there in the middle and swiftly crash as the engine continues to fetch nonsense data.

I'm fairly new to assembly so there might be a more elegant way to solve it, but what I did is simply stick another label after the `rts` called `@advance_pointer` which does the necessary number of `iny`s to get it where it's supposed to be, then jumps back up to finish normally.

Thank you so much for translating this btw, I was able to use it in my chiptune program! Cheers.